### PR TITLE
Sanitize Json Helper Function to Avoid Json Parsing Issues while Translation and Reloading Json Objects post Translation

### DIFF
--- a/statesman-engine/src/main/java/io/appform/statesman/engine/handlebars/HandleBarsHelperRegistry.java
+++ b/statesman-engine/src/main/java/io/appform/statesman/engine/handlebars/HandleBarsHelperRegistry.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Helper;
 import com.github.jknack.handlebars.Options;
@@ -106,6 +107,7 @@ public class HandleBarsHelperRegistry {
         registerTrimDecimalPointsPtr();
         registerIsDigits();
         registerValueFromJsonString();
+        registerSanitizeJson();
     }
 
     private Object compareGte(int lhs) {
@@ -1123,6 +1125,17 @@ public class HandleBarsHelperRegistry {
                 log.error("Exception occurred while removing decimal points", e);
             }
             return "";
+        });
+    }
+
+    private void registerSanitizeJson() {
+        handlebars.registerHelper("sanitizeJson", (String str, Options options) -> {
+            if (Strings.isNullOrEmpty(str)) {
+                return "";
+            } else {
+                val text = TextNode.valueOf(str).toString();
+                return text.substring(1, text.length() - 1);
+            }
         });
     }
 

--- a/statesman-engine/src/main/java/io/appform/statesman/engine/handlebars/HandleBarsHelperRegistry.java
+++ b/statesman-engine/src/main/java/io/appform/statesman/engine/handlebars/HandleBarsHelperRegistry.java
@@ -1133,8 +1133,7 @@ public class HandleBarsHelperRegistry {
             if (Strings.isNullOrEmpty(str)) {
                 return "";
             } else {
-                val text = TextNode.valueOf(str).toString();
-                return text.substring(1, text.length() - 1);
+                return TextNode.valueOf(str).toString();
             }
         });
     }

--- a/statesman-engine/src/test/java/io/appform/statesman/engine/handlebars/HandleBarsServiceTest.java
+++ b/statesman-engine/src/test/java/io/appform/statesman/engine/handlebars/HandleBarsServiceTest.java
@@ -1023,7 +1023,7 @@ public class HandleBarsServiceTest {
 
         val newLineTransform = hb.transform("{{sanitizeJson body/0}}",
             mapper.createObjectNode().set("body",
-                mapper.createArrayNode().add("\n\n\n")));
+                mapper.createArrayNode().add("\n\"\n\n")));
         val expected = "\\n\\n\\n";
         Assert.assertEquals(expected, newLineTransform);
 

--- a/statesman-engine/src/test/java/io/appform/statesman/engine/handlebars/HandleBarsServiceTest.java
+++ b/statesman-engine/src/test/java/io/appform/statesman/engine/handlebars/HandleBarsServiceTest.java
@@ -1014,4 +1014,29 @@ public class HandleBarsServiceTest {
                 mapper.createObjectNode().set("message", TextNode.valueOf("Help")));
         Assert.assertEquals(expectedMisMatch, noMatch);
     }
+
+    @Test
+    public void testSanitizeJson() {
+
+        val hb = new HandleBarsService();
+        val mapper = Jackson.newObjectMapper();
+
+        val newLineTransform = hb.transform("{{sanitizeJson body/0}}",
+            mapper.createObjectNode().set("body",
+                mapper.createArrayNode().add("\n\n\n")));
+        val expected = "\\n\\n\\n";
+        Assert.assertEquals(expected, newLineTransform);
+
+        val backSlashTransformation = hb.transform("{{sanitizeJson body/0}}",
+            mapper.createObjectNode().set("body",
+                mapper.createArrayNode().add("\\\\\\")));
+        val expectedBackSlash = "\\\\\\\\\\\\";
+        Assert.assertEquals(expectedBackSlash, backSlashTransformation);
+
+        val tabTransform = hb.transform("{{sanitizeJson body/0}}",
+            mapper.createObjectNode().set("body",
+                mapper.createArrayNode().add("\t")));
+        val expectedTab = "\\t";
+        Assert.assertEquals(expectedTab, tabTransform);
+    }
 }


### PR DESCRIPTION
It will handle all special chars from \t, \n, \r, \, etc...